### PR TITLE
Fixes from `zizmor` + add attestations and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,13 +16,13 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: free up disk space
         run: ./free-disk-space.sh
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.12.8
 
@@ -31,7 +31,7 @@ jobs:
           ./main.sh ${{ inputs.emcc_version }} ${{ inputs.rust_nightly_date }}
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "emcc-${{ inputs.emcc_version }}_nightly-${{ inputs.rust_nightly_date }}.tar.bz2"
           tag: emcc-${{ inputs.emcc_version }}_nightly-${{ inputs.rust_nightly_date }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,14 +9,24 @@ on:
         description: Rust nightly date
         required: true
 
+env:
+  EMCC_VERSION: ${{ inputs.emcc_version }}
+  RUST_NIGHTLY_DATE: ${{ inputs.rust_nightly_date }}
+
+permissions: {}
+
 jobs:
   pyodide-packages:
     name: Build & Publish rust emscripten-wasm-eh sysroot
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: free up disk space
         run: ./free-disk-space.sh
@@ -28,12 +38,38 @@ jobs:
 
       - name: Build Rust sysroot
         run: |
-          ./main.sh ${{ inputs.emcc_version }} ${{ inputs.rust_nightly_date }}
+          ./main.sh ${EMCC_VERSION} ${RUST_NIGHTLY_DATE}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}
+          path: emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}.tar.bz2
+          if-no-files-found: error
+
+  publish:
+    name: Publish rust emscripten-wasm-eh sysroot
+    runs-on: ubuntu-latest
+    needs: [pyodide-packages]
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: upload
+          merge-multiple: true
+
+      - name: Generate artifact attestation(s)
+        uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
+        with:
+          subject-path: "upload/*.tar.bz2"
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
-          artifacts: "emcc-${{ inputs.emcc_version }}_nightly-${{ inputs.rust_nightly_date }}.tar.bz2"
-          tag: emcc-${{ inputs.emcc_version }}_nightly-${{ inputs.rust_nightly_date }}
+          artifacts: "emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}.tar.bz2"
+          tag: emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}
           draft: false
           prerelease: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Create GitHub Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
-          artifacts: "emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}.tar.bz2"
+          artifacts: "upload/emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}.tar.bz2"
           tag: emcc-${EMCC_VERSION}_nightly-${RUST_NIGHTLY_DATE}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Description

- Pins all workflows to their hashes
- Adds fixes for issues noticed via `zizmor` (try it out with `pipx run zizmor .github/workflows --pedantic`)
- Adds attestations, separates build and publish jobs to not overly grant permissions
- Adds Dependabot with a monthly cadence